### PR TITLE
feat: embed compile-time package.path to bundler searcher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ build: $(DIST)
 
 $(TEST_LIB):
 	mkdir -p $(LIB)
-	curl -sSL https://github.com/Tsukina-7mochi/lua-testing-library/releases/latest/download/test.lua > $(TEST_LIB)
+	curl -sSL https://github.com/Tsukina-7mochi/syzygy/releases/latest/download/syzygy.lua > $(TEST_LIB)
 
 .PHONY: test-self-build
 test-self-build: build

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ LUA = lua
 DIST = ./dist
 LIB = ./lib
 TEST_LIB = $(LIB)/test.lua
+LUA_PATH = "./?.lua;./?/init.lua"
 
 all: build
 
@@ -9,8 +10,8 @@ $(DIST):
 	mkdir -p $(DIST)
 
 build: $(DIST)
-	$(LUA) ./src/cli.lua -e src.neblua -o ./dist/neblua.lua
-	$(LUA) ./src/cli.lua -e src.cli -o ./dist/neblua-cli.lua
+	LUA_PATH=$(LUA_PATH) $(LUA) ./src/cli.lua -e src.neblua -o ./dist/neblua.lua
+	LUA_PATH=$(LUA_PATH) $(LUA) ./src/cli.lua -e src.cli -o ./dist/neblua-cli.lua
 
 $(TEST_LIB):
 	mkdir -p $(LIB)
@@ -18,12 +19,12 @@ $(TEST_LIB):
 
 .PHONY: test-self-build
 test-self-build: build
-	$(LUA) ./dist/neblua-cli.lua -e src.cli -o ./dist/temp.lua ./src/cli.lua
+	LUA_PATH=$(LUA_PATH) $(LUA) ./dist/neblua-cli.lua -e src.cli -o ./dist/temp.lua ./src/cli.lua
 	test -z "$$(diff ./dist/neblua-cli.lua ./dist/temp.lua)"
 
 .PHONY: test
 test: $(TEST_LIB)
-	$(LUA) ./test/test.lua
+	LUA_PATH=$(LUA_PATH) $(LUA) ./test/test.lua
 
 .PHONY: clean
 clean:

--- a/src/renderer/init.lua
+++ b/src/renderer/init.lua
@@ -18,10 +18,21 @@ local function rawGsubRepl (repl)
     return result
 end
 
+---@param repl string
+---@return string
+local function stringLiteralGsubRepl (repl)
+    local result = repl:gsub("%%", "%%%%"):gsub('"', '\\"')
+    return '"' .. result .. '"'
+end
+
 local initTemplate = requireText("src/renderer/templates/initialization.lua")
 local bootstrapTemplate = requireText("src/renderer/templates/bootstrap.lua")
 local templatePatterns = {
     registry = "__NEBLUA_REGISTRY__",
+    packagePath = "__NEBLUA_PACKAGE_PATH__",
+    templateSeparator = "__NEBLUA_TEMPLATE_SEPARATOR__",
+    pathSeparator = "__NEBLUA_PATH_SEPARATOR__",
+    substitutionPoint = "__NEBLUA_SUBSTITUTION_POINT__",
     entry = "__NEBLUA_ENTRY__",
     fallbackStderr = "__NEBLUA_FALLBACK_STDERR__",
     header = "%-%-%[%[ slot: header %]%]",
@@ -53,9 +64,26 @@ local function render (modules, options)
         table.insert(renderedModules, renderModule(module))
     end
 
+    local pathSeparator = package.config:sub(1, 1)
+    local templateSeparator = package.config:sub(3, 3)
+    local substitutionPoint = package.config:sub(5, 5)
+
     local preload = initTemplate
         :gsub(templatePatterns.registry, rawGsubRepl(registryName))
-        :gsub(templatePatterns.entry, '"' .. rawGsubRepl(options.entry) .. '"')
+        :gsub(templatePatterns.packagePath, stringLiteralGsubRepl(package.path))
+        :gsub(
+            templatePatterns.templateSeparator,
+            stringLiteralGsubRepl(templateSeparator)
+        )
+        :gsub(
+            templatePatterns.pathSeparator,
+            stringLiteralGsubRepl(pathSeparator)
+        )
+        :gsub(
+            templatePatterns.substitutionPoint,
+            stringLiteralGsubRepl(substitutionPoint)
+        )
+        :gsub(templatePatterns.entry, stringLiteralGsubRepl(options.entry))
         :gsub(templatePatterns.fallbackStderr, tostring(options.fallbackStderr))
         :gsub(templatePatterns.header, tostring(options.header))
         :gsub(templatePatterns.preInit, tostring(options.preInitCode))
@@ -63,7 +91,20 @@ local function render (modules, options)
 
     local bootstrap = bootstrapTemplate
         :gsub(templatePatterns.registry, rawGsubRepl(registryName))
-        :gsub(templatePatterns.entry, '"' .. rawGsubRepl(options.entry) .. '"')
+        :gsub(templatePatterns.packagePath, stringLiteralGsubRepl(package.path))
+        :gsub(
+            templatePatterns.templateSeparator,
+            stringLiteralGsubRepl(templateSeparator)
+        )
+        :gsub(
+            templatePatterns.pathSeparator,
+            stringLiteralGsubRepl(pathSeparator)
+        )
+        :gsub(
+            templatePatterns.substitutionPoint,
+            stringLiteralGsubRepl(substitutionPoint)
+        )
+        :gsub(templatePatterns.entry, stringLiteralGsubRepl(options.entry))
         :gsub(templatePatterns.fallbackStderr, tostring(options.fallbackStderr))
         :gsub(templatePatterns.preRun, tostring(options.preRunCode))
         :gsub(templatePatterns.postRun, tostring(options.postRunCode))

--- a/src/renderer/templates/bootstrap.lua
+++ b/src/renderer/templates/bootstrap.lua
@@ -52,10 +52,12 @@ return (function (...)
     local function bundlerSearcher (moduleName)
         moduleName = moduleName:gsub("%.", internalPathSeparator)
 
-        for template in split(package.path, templateSeparator) do
+        for template in
+            split(__NEBLUA_PACKAGE_PATH__, __NEBLUA_TEMPLATE_SEPARATOR__)
+        do
             local path = template
-                :gsub(pathSeparator, internalPathSeparator)
-                :gsub(substitutionPoint, moduleName)
+                :gsub(__NEBLUA_PATH_SEPARATOR__, internalPathSeparator)
+                :gsub(__NEBLUA_SUBSTITUTION_POINT__, moduleName)
 
             local module = package.nebluaModule[normalizePath(path)]
             if module ~= nil and module.loader ~= nil then

--- a/src/renderer/templates/meta.lua
+++ b/src/renderer/templates/meta.lua
@@ -3,7 +3,13 @@
 ---@type unknown
 local unknown
 
+package.nebluaModule = unknown --[[@as table<string, { line: integer, loader: function }>]]
+
 __NEBLUA_REGISTRY__ = unknown --[[@as table<string, unknown>]]
+__NEBLUA_PACKAGE_PATH__ = unknown --[[@as string]]
+__NEBLUA_TEMPLATE_SEPARATOR__ = unknown --[[@as string]]
+__NEBLUA_PATH_SEPARATOR__ = unknown --[[@as string]]
+__NEBLUA_SUBSTITUTION_POINT__ = unknown --[[@as string]]
 __NEBLUA_ENTRY__ = unknown --[[@as string]]
 __NEBLUA_FILE_NAME__ = unknown --[[@as string]]
 __NEBLUA_FALLBACK_STDERR__ = unknown --[[@as boolean]]


### PR DESCRIPTION
close: #60 

Embed compile-time `package.path` to template of bundler searcher instead of using run-time `package.path`. This allows simulation of compile-time module resolution performed in [resolver](https://github.com/Tsukina-7mochi/neblua/blob/1b0155d64d9c545aa29e706fc3e9f94986d4ff58/src/resolver.lua#L88-L89).